### PR TITLE
Use generic method of determining user's home directory

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -19,7 +19,7 @@ date=$(date "+%F")
 backupwhat=WHAT_TO_BACKUP
 googledrive=GOOGLE_DRIVE_DIRECTORY/$pc-$type-$date.tgz
 onedrive=ONE_DRIVE_DIRECTORY/$pc-$type-$date.tgz
-tempftp=/Users/robertschmicker/Temp_Documents/$pc-$type-$date.tgz
+tempftp=$HOME/Temp_Documents/$pc-$type-$date.tgz
 #################################################################
 
 tar -cZf "$googledrive" $backupwhat


### PR DESCRIPTION
This change should bring the script closer to working cross-platform, because not all OSes use `/Users` as the home directory (Linux uses `/home`) and not everyone uses the username robertschmicker. :)

Pull this PR, or don't, I don't really mind either way.